### PR TITLE
Initialize git directories for private repositories

### DIFF
--- a/oct/ansible/oct/roles/repositories/tasks/initialize_repository_placeholder.yml
+++ b/oct/ansible/oct/roles/repositories/tasks/initialize_repository_placeholder.yml
@@ -1,0 +1,34 @@
+---
+- name: '{{ origin_ci_repository }} : initialize the source'
+  file:
+    path: '{{ origin_ci_gopath }}/src/github.com/openshift/{{ origin_ci_repository }}'
+    state: 'directory'
+
+- name: '{{ origin_ci_repository }} : initialize the source repository placeholder'
+  command: 'git init'
+  args:
+    chdir: '{{ origin_ci_gopath }}/src/github.com/openshift/{{ origin_ci_repository }}'
+
+- name: '{{ origin_ci_repository }} : determine current Git configuration to allow for idempotency'
+  command: '/usr/bin/git config --list'
+  args:
+    chdir: '{{ origin_ci_gopath }}/src/github.com/openshift/{{ origin_ci_repository }}'
+  register: origin_ci_repository_config_probe
+
+- name: '{{ origin_ci_repository }} : allow pushes to happen to the current branch'
+  command: '/usr/bin/git config --add receive.denyCurrentBranch ignore'
+  args:
+    chdir: '{{ origin_ci_gopath }}/src/github.com/openshift/{{ origin_ci_repository }}'
+  when: "'receive.denycurrentbranch=ignore' not in origin_ci_repository_config_probe.stdout"
+
+- name: '{{ origin_ci_repository }} : allow unsafe fast-forward pushes to the repository'
+  command: '/usr/bin/git config --add receive.denyNonFastForwards false'
+  args:
+    chdir: '{{ origin_ci_gopath }}/src/github.com/openshift/{{ origin_ci_repository }}'
+  when: "'receive.denynonfastforwards=false' not in origin_ci_repository_config_probe.stdout"
+
+- name: '{{ origin_ci_repository }} : allow pushes to happen from the owning group'
+  command: '/usr/bin/git config --add core.sharedRepository group'
+  args:
+    chdir: '{{ origin_ci_gopath }}/src/github.com/openshift/{{ origin_ci_repository }}'
+  when: "'core.sharedrepository=group' not in origin_ci_repository_config_probe.stdout"

--- a/oct/ansible/oct/roles/repositories/tasks/main.yml
+++ b/oct/ansible/oct/roles/repositories/tasks/main.yml
@@ -20,6 +20,14 @@
     - 'origin-metrics'
     - 'origin-aggregated-logging'
 
+- name: initialize git directories for each private repository
+  include: initialize_repository_placeholder.yml
+  vars:
+    origin_ci_repository: '{{ item }}'
+  with_items:
+    - 'ose'
+    - 'online'
+
 - name: ensure the repository management group exists
   group:
     name: '{{ origin_ci_user }}-git'

--- a/oct/cli/util/repository_options.py
+++ b/oct/cli/util/repository_options.py
@@ -15,6 +15,7 @@ class Repository(object):
     source_to_image = 'source-to-image'
     metrics = 'origin-metrics'
     logging = 'origin-aggregated-logging'
+    online = 'online'
 
 
 def repository_argument(func):
@@ -32,5 +33,6 @@ def repository_argument(func):
             Repository.source_to_image,
             Repository.metrics,
             Repository.logging,
+            Repository.online,
         ])
     )(func)


### PR DESCRIPTION
Users will now be able to sync from local source:

    $ oct sync local online
    $ oct sync local ose

This allows for transfer of private repositories from the local host
to the remote host. This is the preferred method of depositing private
repositories on the remote host, instead of transferring fetch keys.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>