### PR TITLE
Add a `build' stage for images

### DIFF
--- a/oct/ansible/oct/playbooks/package/ami.yml
+++ b/oct/ansible/oct/playbooks/package/ami.yml
@@ -43,7 +43,8 @@
       set_fact:
         origin_ci_image_upgrades:
           bare: base
-          base: install
+          base: build
+          build: install
 
     - name: update image stage if we are upgrading stages
       set_fact:

--- a/oct/cli/package/common_options.py
+++ b/oct/cli/package/common_options.py
@@ -32,6 +32,8 @@ def next_stage(current_stage):
     if current_stage == Stage.bare:
         return Stage.base
     elif current_stage == Stage.base:
+        return Stage.build
+    elif current_stage == Stage.build:
         return Stage.install
     elif current_stage == Stage.install:
         echo('Warning: No next stage exists past the "{}" stage. Overwriting current stage instead.'.format(Stage.install))

--- a/oct/cli/provision/group.py
+++ b/oct/cli/provision/group.py
@@ -25,7 +25,8 @@ and install process your VM begins. The following stages are supported:
 \b
  - bare: bare operating system
  - base: RPM dependencies installed and configured, repositories cloned
- - install: artifacts and binaries built and installed from repositories
+ - build: artifacts and binaries built from repositories
+ - install: OpenShift cluster installed from artifacts
 
 Your choice of stage is not final: it is always possible to use
 this tool to 'upgrade' your stage by running sync and install jobs

--- a/oct/cli/provision/local/all_in_one.py
+++ b/oct/cli/provision/local/all_in_one.py
@@ -36,6 +36,7 @@ class Stage(object):
     """
     bare = 'bare'
     base = 'base'
+    build = 'build'
     install = 'install'
 
 
@@ -95,6 +96,7 @@ Examples:
     type=Choice([
         Stage.bare,
         Stage.base,
+        Stage.build,
         Stage.install,
     ]),
     default=Stage.install,

--- a/oct/cli/provision/remote/all_in_one.py
+++ b/oct/cli/provision/remote/all_in_one.py
@@ -32,6 +32,7 @@ class Stage(object):
     """
     bare = 'bare'
     base = 'base'
+    build = 'build'
     install = 'install'
 
 
@@ -103,6 +104,7 @@ Examples:
     type=Choice([
         Stage.bare,
         Stage.base,
+        Stage.build,
         Stage.install,
     ]),
     default=Stage.install,


### PR DESCRIPTION
As a stop-gap between raw source code and a fully installed OpenShift
cluster, the `build` image stage should contain built artifacts from the
component repositories. This will lessen the cost of using these images
while a functional `install` image can be built.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>