### PR TITLE
Remove RDS and Elasticache from ec2 inventory

### DIFF
--- a/oct/ansible/oct/roles/aws-up/templates/ec2.j2
+++ b/oct/ansible/oct/roles/aws-up/templates/ec2.j2
@@ -5,6 +5,8 @@ destination_variable = {{ origin_ci_aws_destination_variable }}
 vpc_destination_variable = {{ origin_ci_aws_vpc_destination_variable }}
 
 route53 = False
+rds = False
+elasticache = False
 
 cache_path = {{ origin_ci_aws_cache_dir }}
 cache_max_age = 300


### PR DESCRIPTION
Neither the RDS nor the Elasticache queries done by the default Ansible
EC2 dynamic inventory are necessary for our needs. These queries also
require a higher level of privileges than we can expect from all users,
so we just remove these queries from the inventory configuration.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>