### PR TITLE
Add `release` and `aos-cd-jobs` repositories to base

### DIFF
--- a/oct/ansible/oct/callback_plugins/pretty_progress.py
+++ b/oct/ansible/oct/callback_plugins/pretty_progress.py
@@ -469,7 +469,10 @@ def format_result(result):
     # detect internal stacktrace crashes
     full_message += format_internal_exception_output(result)
     full_message += format_parsing_error(result)
-    return full_message
+
+    # filter out empty lines and lines of only whitespace
+    full_message = [line for line in full_message.splitlines() if line and line.strip()]
+    return "\n".join(full_message)
 
 
 def format_failure_message(result):

--- a/oct/ansible/oct/playbooks/bootstrap/self.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/self.yml
@@ -61,3 +61,4 @@
         - ruby-devel
         - vagrant
         - libguestfs-tools
+      when: origin_ci_bootstrap_image_dependencies

--- a/oct/ansible/oct/roles/repositories/tasks/main.yml
+++ b/oct/ansible/oct/roles/repositories/tasks/main.yml
@@ -20,6 +20,8 @@
     - 'origin-metrics'
     - 'origin-aggregated-logging'
     - 'openshift-ansible'
+    - 'release'
+    - 'aos-cd-jobs'
 
 - name: initialize git directories for each private repository
   include: initialize_repository_placeholder.yml


### PR DESCRIPTION
Handle excess whitespace better in `pretty_progress`

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Only install image dependencies when asked

The previous behavior to install image dependencies on the host
regardless of whether the user asked for them or not was incorrect.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Add `release` and `aos-cd-jobs` repositories to base

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
