### PR TITLE
Install tools using the Go package manager

### DIFF
--- a/oct/ansible/oct/callback_plugins/pretty_progress.py
+++ b/oct/ansible/oct/callback_plugins/pretty_progress.py
@@ -609,15 +609,17 @@ class Failure(object):
         :return: the formatted error
         """
         full_message = colorize('A task failed on host `{}`!\n'.format(self.host), color=COLOR_ERROR)
-        full_message += format_result(self.result)
+        result = format_result(self.result)
 
-        if full_message.count('\n') == 1:
+        if len(result.splitlines()) == 0:
             # we have not been able to get any use-able
             # messages from the result, so we should
             # tell the user to look at the logs
             # TODO: better OS-agnostic filesystem code for this
             log_location = join(environ.get('ANSIBLE_LOG_ROOT_PATH', join('tmp', 'ansible', 'log')), '/', '{}'.format(self.host))
             full_message += 'No useful error messages could be extracted, see full output at {}\n'.format(log_location)
+        else:
+            full_message += result
 
         return full_message
 

--- a/oct/ansible/oct/playbooks/prepare/golang.yml
+++ b/oct/ansible/oct/playbooks/prepare/golang.yml
@@ -44,3 +44,13 @@
   roles:
     - role: isolated-install
       origin_ci_isolated_package_name: 'golang'
+
+  post_tasks:
+    - name: install golang ecosystem tooling
+      command: 'go get {{ item }}'
+      with_items:
+        - 'golang.org/x/tools/cmd/cover'
+        - 'golang.org/x/tools/cmd/goimports'
+        - 'github.com/tools/godep'
+        - 'github.com/golang/lint/golint'
+        - 'github.com/openshift/imagebuilder/cmd/imagebuilder'

--- a/oct/cli/util/repository_options.py
+++ b/oct/cli/util/repository_options.py
@@ -16,6 +16,9 @@ class Repository(object):
     metrics = 'origin-metrics'
     logging = 'origin-aggregated-logging'
     online = 'online'
+    release = 'release'
+    aoscdjobs = 'aos-cd-jobs'
+    openshift_ansible = 'openshift-ansible'
 
 
 def repository_argument(func):
@@ -34,5 +37,8 @@ def repository_argument(func):
             Repository.metrics,
             Repository.logging,
             Repository.online,
+            Repository.release,
+            Repository.aoscdjobs,
+            Repository.openshift_ansible,
         ])
     )(func)


### PR DESCRIPTION
Improve logic for `pretty_progress` error output

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Install tools using the Go package manager

For tools we use from the Go ecosystem, we need to install them using
the `go get` mechanism after we install `go`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

