### PR TITLE
Persist `$GOPATH` on `golang` install

### DIFF
--- a/oct/ansible/oct/playbooks/prepare/golang.yml
+++ b/oct/ansible/oct/playbooks/prepare/golang.yml
@@ -46,6 +46,19 @@
       origin_ci_isolated_package_name: 'golang'
 
   post_tasks:
+    - name: persist the GOPATH
+      lineinfile:
+        dest: /etc/environment
+        regexp: '^GOPATH='
+        line: 'GOPATH={{ origin_ci_gopath | default("/data") }}'
+        state: present
+        create: true
+
+    - name: ensure the GOPATH exists
+      file:
+        path: '{{ origin_ci_gopath }}'
+        state: directory
+
     - name: install golang ecosystem tooling
       command: 'go get {{ item }}'
       with_items:

--- a/oct/ansible/oct/roles/repositories/tasks/main.yml
+++ b/oct/ansible/oct/roles/repositories/tasks/main.yml
@@ -55,14 +55,6 @@
     - '{{ ansible_user_id }}'
     - '{{ ansible_env.SUDO_USER }}'
 
-- name: persist the GOPATH
-  lineinfile:
-    dest: /etc/environment
-    regexp: '^GOPATH='
-    line: 'GOPATH={{ origin_ci_gopath }}'
-    state: present
-    create: true
-
 - name: determine current Git configuration to allow for idempotency
   command: '/usr/bin/git config --list --global'
   register: origin_ci_global_config_probe


### PR DESCRIPTION
In order to be able to use the `go` tooling before repositories are
created and synced, we need to create and persist the `$GOPATH` after
the `golang` tools are installed.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>