### PR TITLE
Create all directories necessary for inventory on first run

### DIFF
--- a/oct/config/ansible_client.py
+++ b/oct/config/ansible_client.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 from time import sleep
-from os import environ, mkdir
+from os import environ, mkdir, makedirs
 from os.path import abspath, dirname, exists, join
 
 from __main__ import display  # pylint: disable=no-name-in-module
@@ -130,7 +130,7 @@ class AnsibleCoreClient(object):
         # that the directory for it exists, at the least, so
         # ansible doesn't complain
         if not exists(self.host_list):
-            mkdir(self.host_list)
+            makedirs(self.host_list)
 
         variable_manager = VariableManager()
         data_loader = DataLoader()


### PR DESCRIPTION
When the inventory directory does not exist, on the first run of `oct`,
it is necessary to create it. This will fail, however, if any of the
parent directories are also missing. We should create whatever dirs are
necessary and not worry about this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes #74 