### PR TITLE
Stop EC2 instances instead of terminating them

### DIFF
--- a/oct/ansible/oct/roles/aws-down/tasks/main.yml
+++ b/oct/ansible/oct/roles/aws-down/tasks/main.yml
@@ -16,7 +16,7 @@
   ec2:
     region: '{{ origin_ci_aws_region }}'
     instance_ids: [ '{{ origin_ci_aws_instance_id }}' ]
-    state: absent
+    state: stopped
 
 - name: remove the serialized host variables
   file:


### PR DESCRIPTION
Most permission levels cannot terminate an EC2 instance outright so it
is better to rename the instance to `terminate` and change the instance
state to `stopped` to allow for the termination reaper to handle the
rest of the transaction.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>