### PR TITLE
Don't check GPG signatures for CentOS PaaS SIG

### DIFF
--- a/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
@@ -56,7 +56,7 @@
     state: present
     description: '{{ item.description }}'
     baseurl: '{{ item.url }}'
-    gpgcheck: yes
+    gpgcheck: no
     sslverify: no
     sslclientcert: /var/lib/yum/client-cert.pem
     sslclientkey: /var/lib/yum/client-key.pem


### PR DESCRIPTION
We trust the builds on the CentOS PaaS SIG repositories and it does not
make sense for us to require those packages to be signed. Furthermore
the `-future` repositories in that domain will not published signed
packages in the future.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>