### PR TITLE
Ensure the PyPy package name is `origin-ci-tool`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_requires = base_requires + [
 ]
 
 setup(
-    name='oct',
+    name='origin-ci-tool',
     version='0.1.0',
     url='https://www.github.com/openshift/origin-ci-tool',
     maintainer='Steve Kuznetsov',


### PR DESCRIPTION
The `oct` package is already registered in the PyPy database and we
cannot clash with that if we want to install using `pip` without the
Git address hacks later.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @php-coder 