### PR TITLE
Import name, not module, from Ansible plugins

### DIFF
--- a/oct/ansible/oct/callback_plugins/default_with_output_lists.py
+++ b/oct/ansible/oct/callback_plugins/default_with_output_lists.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from copy import deepcopy
 
-from ansible.plugins.callback import default
+from ansible.plugins.callback.default import CallbackModule as DefaultCallbackModule
 
 
-class CallbackModule(default.CallbackModule):
+class CallbackModule(DefaultCallbackModule):
     """
     This CallbackModule overrides the default stdout
     callback plugin to always use arrays for stderr


### PR DESCRIPTION
Ansible apparently does some fancy trickery which changes the order in
which different modules are loaded for plugins, which means that in some
situations the import for the `ansible.plugins.callback.default` module
would fail. Instead, we alias a name from the module for our use.

See also:
  https://github.com/ansible/ansible/commit/1714279b5e18cdc3f684e5ea3af5416b5f0c8c67

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton @enj 