### PR TITLE
Update isolated install to work for repo URL without whitelist

### DIFF
--- a/oct/ansible/oct/roles/aws-up/tasks/main.yml
+++ b/oct/ansible/oct/roles/aws-up/tasks/main.yml
@@ -134,22 +134,23 @@
 
 - name: determine where updated SSH configuration should go
   set_fact:
-    origin_ci_ssh_config_file: '{{ origin_ci_inventory_dir }}/.ssh_config'
+    origin_ci_ssh_config_files: ['{{ origin_ci_inventory_dir }}/.ssh_config']
   when: origin_ci_ssh_config_strategy == 'discrete'
 
 - name: determine where updated SSH configuration should go
   set_fact:
-    origin_ci_ssh_config_file: '{{ ansible_env.HOME }}/.ssh/config'
+    origin_ci_ssh_config_files: ['{{ origin_ci_inventory_dir }}/.ssh_config', '{{ ansible_env.HOME }}/.ssh/config']
   when: origin_ci_ssh_config_strategy == 'update'
 
 - name: ensure the targeted SSH configuration file exists
   file:
-    path: '{{ origin_ci_ssh_config_file }}'
+    path: '{{ item }}'
     state: touch
+  with_items: origin_ci_ssh_config_files
 
 - name: update the SSH configuration
   blockinfile:
-    dest: '{{ origin_ci_ssh_config_file }}'
+    dest: '{{ item }}'
     block: >
       Host {{ origin_ci_aws_hostname }} {{ origin_ci_aws_host }}
         HostName {{ origin_ci_aws_host }}
@@ -163,3 +164,4 @@
         LogLevel FATAL
     state: present
     marker: '# {mark} ANSIBLE MANAGED BLOCK FOR HOST {{ origin_ci_aws_hostname }}'
+  with_items: origin_ci_ssh_config_files

--- a/oct/ansible/oct/roles/isolated-install/defaults/main.yml
+++ b/oct/ansible/oct/roles/isolated-install/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-origin_ci_tmp_repofile: /etc/yum.repos.d/origin_ci_tool_tmp.repo
+origin_ci_tmp_repofile: /etc/yum.repos.d/origin_ci_tool_tmp

--- a/oct/ansible/oct/roles/isolated-install/tasks/main.yml
+++ b/oct/ansible/oct/roles/isolated-install/tasks/main.yml
@@ -50,22 +50,14 @@
 
 - name: 'add temporary repositories to the whitelist for install'
   set_fact:
-    origin_ci_isolated_enabledrepos: "{{ origin_ci_isolated_enabledrepos }},{{ item | regex_replace('[^a-zA-Z0-9]', '') }}"
-  with_items: '{{ origin_ci_isolated_tmp_repourls | default([]) }}'
-
-- name: 'install {{ origin_ci_isolated_package }} using default repos'
-  package:
-    name: '{{ origin_ci_isolated_package }}'
-    state: present
-  when: origin_ci_isolated_enabledrepos is not defined
+    origin_ci_isolated_enabledrepos: "{{ ( (origin_ci_isolated_enabledrepos | default() | list) + (origin_ci_isolated_tmp_repourls | map('regex_replace', '[^a-zA-Z0-9]', '') | list) ) | join(',') }}"
 
 - name: 'install {{ origin_ci_isolated_package }} using selected repos'
   yum:
     name: '{{ origin_ci_isolated_package }}'
     state: present
-    disablerepo: '{{ origin_ci_isolated_disabledrepos }}'
-    enablerepo: '{{ origin_ci_isolated_enabledrepos }}'
-  when: origin_ci_isolated_enabledrepos is defined
+    disablerepo: '{{ origin_ci_isolated_disabledrepos | default(omit) }}'
+    enablerepo: '{{ origin_ci_isolated_enabledrepos | default(omit) }}'
 
 - name: 'remove temporary repositories that we needed to install {{ origin_ci_isolated_package }}'
   yum_repository:

--- a/oct/config/ansible_client.py
+++ b/oct/config/ansible_client.py
@@ -190,4 +190,4 @@ class AnsibleCoreClient(object):
         if result != TaskQueueManager.RUN_OK:
             # TODO: this seems bad, but can we discover the thread here to join() it?
             sleep(0.2)
-            raise ClickException('Playbook execution failed with code ' + str(result))
+            raise ClickException('\nPlaybook execution failed with code ' + str(result))


### PR DESCRIPTION
Update isolated install to work for repo URL without whitelist

Previously the playbook to do an isolated package install would not work
if the package source was given as a URL and no additional repositories
were whitelisted for the installation.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Add a discrete SSH configuration file always

In case something goes wrong or other processes touch the configuration
at `$HOME/.ssh_config`, we should just place the discrete file in all
cases.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
