### PR TITLE
Don't allow tasks to fail instead of ignoring errors

### DIFF
--- a/oct/ansible/oct/playbooks/provision/vagrant-docker-storage.yml
+++ b/oct/ansible/oct/playbooks/provision/vagrant-docker-storage.yml
@@ -31,7 +31,7 @@
   tasks:
     - name: probe for the Docker volume group
       command: '/usr/sbin/lvs {{ origin_ci_docker_volume_group }}'
-      ignore_errors: yes
+      failed_when: no
       register: origin_ci_docker_volume_group_probe
 
     - name: determine if we should be skipping the rest of the plays or not

--- a/oct/ansible/oct/roles/aws-up/tasks/main.yml
+++ b/oct/ansible/oct/roles/aws-up/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: determine if we are inside AWS EC2
   command: 'curl -s http://instance-data.ec2.internal'
-  ignore_errors: yes
+  failed_when: no
   register: ec2_probe
 
 - name: configure EC2 parameters for inventory when controlling from inside EC2

--- a/oct/ansible/oct/roles/local-sync/tasks/main.yml
+++ b/oct/ansible/oct/roles/local-sync/tasks/main.yml
@@ -14,14 +14,14 @@
   args:
     chdir: '{{ origin_ci_sync_source }}'
   register: origin_ci_sync_staged_commit
-  ignore_errors: yes
+  failed_when: no
 
 - name: attempt to commit unstaged changes
   command: '/usr/bin/git commit --all --message="<AUTOMATED COMMIT OF UNSTAGED CHANGES>"'
   args:
     chdir: '{{ origin_ci_sync_source }}'
   register: origin_ci_sync_unstaged_commit
-  ignore_errors: yes
+  failed_when: no
 
 - name: push local changes to the remotes
   command: >

--- a/oct/ansible/oct/roles/repositories/tasks/main.yml
+++ b/oct/ansible/oct/roles/repositories/tasks/main.yml
@@ -58,7 +58,7 @@
 - name: determine current Git configuration to allow for idempotency
   command: '/usr/bin/git config --list --global'
   register: origin_ci_global_config_probe
-  ignore_errors: yes
+  failed_when: no
   become: yes
   become_user: '{{ origin_ci_user }}'
 

--- a/oct/ansible/oct/roles/vagrant-up/tasks/main.yml
+++ b/oct/ansible/oct/roles/vagrant-up/tasks/main.yml
@@ -19,7 +19,7 @@
   command: '/usr/bin/vagrant status {{ origin_ci_vagrant_hostname }}'
   args:
     chdir: '{{ origin_ci_vagrant_home_dir }}'
-  ignore_errors: yes
+  failed_when: no
   register: origin_ci_vagrant_status
 
 - name: provision the VM with Vagrant


### PR DESCRIPTION
When tasks are run that may fail but do not cause an error if they do,
if we use `ignore_errors`, any linters or users looking for failed tasks
in the output of the playbook will still see what looks liked a failed
task, if they do not notice the small `...ignoring` message at the end.
As these tasks really cannot ever fail, we can instead use `failed_when`
to never allow them to fail. The logic around them already had to take
into account the case where they failed; in the majority of cases this
also did not use any `succeeded` filters, so we will not break that
logic by making this move.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>


/cc @sdodson does this seem reasonable?