### PR TITLE
Decrease the Journald persistent sync interval

### DIFF
--- a/oct/ansible/oct/roles/dependencies/tasks/pre_install.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/pre_install.yml
@@ -13,10 +13,15 @@
 - name: ensure systemd journal has persistent logs
   lineinfile:
     dest: /etc/systemd/journald.conf
-    regexp: '^Storage='
-    line: 'Storage=persistent'
+    regexp: '^#?{{ item.key }}='
+    line: '{{ item.key }}={{ item.val }}'
     state: present
     create: true
+  with_items:
+    - key: 'Storage'
+      val: 'persistent'
+    - key: 'SyncIntervalSec'
+      val: '1s'
 
 - name: restart the journal
   systemd:


### PR DESCRIPTION
In order to reduce the chance that we lose logs from the persistent
journal, we need to reduce the sync interval for the system journal from
the long default.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @portante 