### PR TITLE
Remove mustaches inside when statements

### DIFF
--- a/oct/ansible/oct/playbooks/package/ami.yml
+++ b/oct/ansible/oct/playbooks/package/ami.yml
@@ -82,7 +82,7 @@
     - name: determine AWS EC2 AMI name
       set_fact:
         origin_ci_aws_ami_name: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_instance_name'] }}"
-      when: "{{ origin_ci_aws_additional_tags }} | length | int > 0"
+      when: "origin_ci_aws_additional_tags | length > 0"
 
     - name: search for an AMI to update
       ec2_ami_find:
@@ -94,12 +94,12 @@
         sort_end: 1
         no_result_action: fail
       register: ami_facts
-      when: "{{ origin_ci_aws_additional_tags }} | length | int > 0"
+      when: "origin_ci_aws_additional_tags | length > 0"
 
     - name: determine which AMI to update
       set_fact:
         origin_ci_aws_ami_id: '{{ ami_facts.results[0].ami_id }}'
-      when: "{{ origin_ci_aws_additional_tags }} | length | int > 0"
+      when: "origin_ci_aws_additional_tags | length > 0"
 
     - name: add any additional tags
       ec2_tag:
@@ -108,4 +108,4 @@
         tags: "{ '{{ item.key }}': '{{ item.value }}' }"
         state: present
       with_dict: '{{ origin_ci_aws_additional_tags }}'
-      when: "{{ origin_ci_aws_additional_tags }} | length | int > 0"
+      when: "origin_ci_aws_additional_tags | length > 0"


### PR DESCRIPTION
Mustaches in 'when' break badly when the dictionary is holding values.
See [1] for more information.

[1] https://github.com/ansible/ansible/issues/13270#issuecomment-209631136

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>