### PR TITLE
Serialize information about new hosts ASAP

### DIFF
--- a/oct/ansible/oct/roles/aws-up/tasks/main.yml
+++ b/oct/ansible/oct/roles/aws-up/tasks/main.yml
@@ -107,14 +107,6 @@
   set_fact:
     origin_ci_aws_host: '{{ ec2.instances[0][origin_ci_aws_host_address_variable] }}'
 
-- name: wait for SSH to be available
-  wait_for:
-    host: '{{ origin_ci_aws_host }}'
-    port: 22
-    delay: 10
-    timeout: 600
-    state: 'started'
-
 - name: determine the default user to use for SSH
   set_fact:
     origin_ci_aws_ssh_user: 'ec2-user'
@@ -175,3 +167,11 @@
     state: present
     marker: '# {mark} ANSIBLE MANAGED BLOCK FOR HOST {{ origin_ci_aws_hostname }}'
   with_items: '{{ origin_ci_ssh_config_files }}'
+
+- name: wait for SSH to be available
+  wait_for:
+    host: '{{ origin_ci_aws_host }}'
+    port: 22
+    delay: 10
+    timeout: 600
+    state: 'started'


### PR DESCRIPTION
When we provision a new host in AWS EC2, we need to serialize
information for connecting to and interacting with that host at the
first possible moment so that we can appropriately deprovision if
anything were to fail later. Currently we wait for the instance to come
up afte we provision it but before we serialize the information, which
means if we fail to see the instance come up we do not have the data
necessary to deprovision it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @dobbymoodge 