### PR TITLE
Prune refs from repo on remote host on sync

### DIFF
--- a/oct/ansible/oct/roles/local-sync/tasks/main.yml
+++ b/oct/ansible/oct/roles/local-sync/tasks/main.yml
@@ -27,7 +27,7 @@
   command: >
     /usr/bin/git push ssh://{{ item }}{{ hostvars[item]['origin_ci_sync_destination'] }} \
                       {{ origin_ci_sync_version }}:{{ origin_ci_sync_version }}          \
-                      --force --tags
+                      --force --tags --prune
   args:
     chdir: '{{ origin_ci_sync_source }}'
   with_items: '{{ groups[origin_ci_hosts] }}' # TODO: this is fragile if literal hosts are passed in. do we care?

--- a/oct/ansible/oct/roles/remote-sync/tasks/main.yml
+++ b/oct/ansible/oct/roles/remote-sync/tasks/main.yml
@@ -42,6 +42,11 @@
     dest: '{{ origin_ci_sync_destination }}'
     force: yes
 
+- name: prune out any refs that should not exist on the remote
+  shell: '/usr/bin/git fetch {{ origin_ci_sync_remote }} --tags --prune'
+  args:
+    chdir: '{{ origin_ci_sync_destination }}'
+
 - name: check out the desired post-merge state, if requested
   shell: '/usr/bin/git checkout {{ origin_ci_sync_merge_target }}'
   args:


### PR DESCRIPTION
When we are doing a sync of a repo on the remote host, we should be
pruning the errant refs and tags there to ensure that the synced code
really resembles the remote it is synced from. For instance, this is
critical when a `tito tag` has been done on the remote host but the tag
has not been pushed anywhere -- if you just sync the code with the
remote, the next `tito tag` will fail as the closest reachable tag will
not be the tag created before, but the tag on the remote, and the tag
created before will remain in the tree on a dangling ref.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>