### PR TITLE
Drop obsolete package options

### DIFF
--- a/oct/ansible/oct/playbooks/package/ami.yml
+++ b/oct/ansible/oct/playbooks/package/ami.yml
@@ -49,7 +49,7 @@
     - name: update image stage if we are upgrading stages
       set_fact:
         origin_ci_aws_ami_stage: '{{ origin_ci_image_upgrades[origin_ci_aws_ami_stage] }}'
-      when: origin_ci_aws_stage_strategy == 'upgrade' or origin_ci_aws_stage_strategy == 'next'
+      when: origin_ci_aws_stage_strategy == 'next'
 
     - name: update image stage if we are upgrading stages
       set_fact:

--- a/oct/cli/package/aws.py
+++ b/oct/cli/package/aws.py
@@ -40,20 +40,18 @@ Examples:
 @ansible_output_options
 @package_options
 @pass_context
-def ami(context, update_current_stage, upgrade_current_stage, upgrade_stage, mark_ready, tags):
+def ami(context, upgrade_stage, mark_ready, tags):
     """
     Package a running AWS EC2 virtual machine.
 
     :param context: Click context
-    :param update_current_stage: [DEPRECATED] update current stage
-    :param upgrade_current_stage: [DEPRECATED] upgrade current stage
     :param upgrade_stage: whether or not to upgrade the current stage
     :param mark_ready: whether or not to mark a previous AMI from this instance ready
     :param tags: tag an AMI with the provided key-value pair
     """
     configuration = context.obj
 
-    validate_options(update_current_stage, upgrade_current_stage, upgrade_stage, mark_ready, tags)
+    validate_options(upgrade_stage, mark_ready, tags)
 
     ami_tags = {}
     for tag in tags:
@@ -63,13 +61,6 @@ def ami(context, update_current_stage, upgrade_current_stage, upgrade_stage, mar
         else:
             key = tag
         ami_tags[key] = value
-
-    if upgrade_stage is not None:
-        origin_ci_aws_stage_strategy = upgrade_stage
-    if update_current_stage:
-        origin_ci_aws_stage_strategy = 'update'
-    if upgrade_current_stage:
-        origin_ci_aws_stage_strategy = 'upgrade'
 
     if mark_ready:
         ami_tags["ready"] = "yes"
@@ -81,23 +72,16 @@ def ami(context, update_current_stage, upgrade_current_stage, upgrade_stage, mar
         configuration.run_playbook(
             playbook_relative_path='package/ami',
             playbook_variables={
-                'origin_ci_aws_stage_strategy': origin_ci_aws_stage_strategy,
+                'origin_ci_aws_stage_strategy': upgrade_stage,
                 'origin_ci_inventory_dir': configuration.ansible_client_configuration.host_list,
                 'origin_ci_aws_additional_tags': ami_tags,
             },
         )
 
 
-def validate_options(update_current_stage, upgrade_current_stage, upgrade_stage, mark_ready, tags):
-    if not mark_ready:
-        if update_current_stage and upgrade_current_stage:
-            raise UsageError('--update and --upgrade options are mutually exclusive')
-        if update_current_stage and upgrade_stage is not None:
-            raise UsageError('--update and --stage options are mutually exclusive')
-        if upgrade_current_stage and upgrade_stage is not None:
-            raise UsageError('--upgrade and --stage options are mutually exclusive')
-        if not update_current_stage and not upgrade_current_stage and upgrade_stage is None:
-            raise UsageError('one of --update, --upgrade, or --stage must be specified')
+def validate_options(upgrade_stage, mark_ready, tags):
+    if not mark_ready and upgrade_stage is None:
+        raise UsageError('--stage must be specified')
 
     for tag in tags:
         if "=" in tag:

--- a/oct/cli/package/common_options.py
+++ b/oct/cli/package/common_options.py
@@ -13,26 +13,12 @@ def package_options(func):
     :param func: Click CLI command to decorate
     :return: decorated CLI command
     """
-    option(
+    return option(
         '--stage',
         '-s',
         'upgrade_stage',
         type=Choice(['current', 'next', 'fork', 'base']),
         help='Update the current stage, upgrade to next default stage, or choose a stage',
-    )(func)
-    option(
-        '--upgrade',
-        '-g',
-        'upgrade_current_stage',
-        is_flag=True,
-        help='[DEPRECATED] Upgrade to next stage.',
-    )(func)
-    return option(
-        '--update',
-        '-d',
-        'update_current_stage',
-        is_flag=True,
-        help='[DEPRECATED] Update the current stage.',
     )(func)
 
 

--- a/oct/cli/package/tests/test_package.py
+++ b/oct/cli/package/tests/test_package.py
@@ -81,42 +81,12 @@ class PackageAMITestCase(PlaybookRunnerTestCase):
             )
         )
 
-    def test_invalid_upgrade(self):
-        self.run_test(
-            TestCaseParameters(
-                args=['package', 'ami', "--stage=fork", "--upgrade"],
-                expected_calls=None,
-                expected_result=CLICK_RC_USAGE,
-                expected_output="--upgrade and --stage options are mutually exclusive",
-            )
-        )
-
-    def test_invalid_update(self):
-        self.run_test(
-            TestCaseParameters(
-                args=['package', 'ami', "--stage=base", "--update"],
-                expected_calls=None,
-                expected_result=CLICK_RC_USAGE,
-                expected_output="--update and --stage options are mutually exclusive",
-            )
-        )
-
     def test_no_options(self):
         self.run_test(
             TestCaseParameters(
                 args=['package', 'ami'],
                 expected_calls=None,
                 expected_result=CLICK_RC_USAGE,
-                expected_output="one of --update, --upgrade, or --stage must be specified",
-            )
-        )
-
-    def test_no_options(self):
-        self.run_test(
-            TestCaseParameters(
-                args=['package', 'ami', "--update", "--upgrade"],
-                expected_calls=None,
-                expected_result=CLICK_RC_USAGE,
-                expected_output="--update and --upgrade options are mutually exclusive",
+                expected_output="--stage must be specified",
             )
         )


### PR DESCRIPTION
Jobs moved to use the new flag in https://github.com/openshift/aos-cd-jobs/pull/275

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>