### PR TITLE
Correctly choose the newest non-fork AMI

### DIFF
--- a/oct/ansible/oct/roles/aws-up/tasks/main.yml
+++ b/oct/ansible/oct/roles/aws-up/tasks/main.yml
@@ -51,7 +51,7 @@
 - name: determine which AMI to use
   set_fact:
     origin_ci_aws_ami_id: '{{ item.ami_id }}'
-  with_items: '{{ ami_facts.results }}'
+  with_items: '{{ ami_facts.results | reverse }}' # we need to reverse so we find the _newest_ non-QE AMI
   when: "'qe' not in item.tags"
 
 - name: determine which subnets are available

--- a/oct/cli/package/aws.py
+++ b/oct/cli/package/aws.py
@@ -24,10 +24,10 @@ Examples:
 \b
   Package a VM for a specific stage
   $ oct package ami --stage fork
-\b  
+\b
   Mark a packaged AMI as ready for use
   $ oct package ami --mark-ready
-\b  
+\b
   Package a VM with custom tags
   $ oct package ami --tag FOO=BAR --tag OTHER=VAL
 ''',


### PR DESCRIPTION
Previously, we iterated through the list of possible AMIs and kept track
of the oldest non-fork AMI to use for provisioning. Instead, we should
have been finding the newest non-fork AMI. By iterating in the other
direction, we can achieve that.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/openshift/origin-ci-tool/issues/106

/cc @kargakis 