### PR TITLE
Increase volume sizes to 35GB

### DIFF
--- a/oct/ansible/oct/roles/aws-up/tasks/main.yml
+++ b/oct/ansible/oct/roles/aws-up/tasks/main.yml
@@ -94,11 +94,11 @@
     volumes:
       - device_name: '/dev/sda1'
         volume_type: 'gp2'
-        volume_size: '25'
+        volume_size: '35'
         delete_on_termination: yes
       - device_name: '/dev/sdb'
         volume_type: 'gp2'
-        volume_size: '25'
+        volume_size: '35'
         delete_on_termination: yes
     wait: yes
     wait_timeout: 600


### PR DESCRIPTION
When we build and/or pull a lot of images, like in the image publishing
job or in the images extended test job, we run out of space on the disk
for all of it. We have already increased this size in Vagrant-OpenShift
but forgot to make the change here.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @bparees @csrwng 