### PR TITLE
Extend AMI creation wait timeout

### DIFF
--- a/oct/ansible/oct/playbooks/package/ami.yml
+++ b/oct/ansible/oct/playbooks/package/ami.yml
@@ -74,7 +74,7 @@
           image_stage: '{{ origin_ci_aws_ami_stage }}'
           ready: 'no'
         wait: yes
-        wait_timeout: 1200
+        wait_timeout: 1800
 
     - name: determine the host variables file for the AWS EC2 host
       set_fact:


### PR DESCRIPTION
I've seen our AMI jobs fail often because of 
```
TASK [package the Amazon machine image from the running instance] **************
task path: /var/lib/jenkins/origin-ci-tool/54f1755641e07ff2be4a3812a9a5937eef8b697c/lib/python2.7/site-packages/oct/ansible/oct/playbooks/package/ami.yml:64
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "generated_timestamp": "2017-06-08 04:46:52.937096", 
    "msg": "Error while trying to find the new image. Using wait=yes and/or a longer wait_timeout may help."
}
```
Looking at the AWS web console, the AMIs seem to show up eventually but since the job has been aborted, they are not tagged eg. look at ami_build_origin_int_rhel_build_374 and its corresponding job that failed (https://ci.openshift.redhat.com/jenkins/view/All/job/ami_build_origin_int_rhel_build/374/). 

@dobbymoodge do we track AMI creation times?

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>