### PR TITLE
Install pip and junit_xml library in dependency stage

### DIFF
--- a/oct/ansible/oct/roles/dependencies/tasks/install_dependencies.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/install_dependencies.yml
@@ -52,6 +52,7 @@
    - openldap-clients         # Origin LDAP tests
    - openssl                  # Origin `test-cmd` tests
    - openvswitch              #
+   - python-pip               # used for ansible plugin deps
    - python-dbus              # OpenShift-Ansible (upstream this)
    - rubygems                 #
    - screen                   # developer UX
@@ -98,6 +99,11 @@
   package:
     name: '*'
     state: latest
+
+- name: install jUnit dependency for Ansible plugins
+  pip:
+    name: junit_xml
+    state: present
 
 - name: determine installed npm version
   command: "repoquery --pkgnarrow=installed --queryformat '%{version}' npm"


### PR DESCRIPTION
Instead of taking ~2min per test run to install `pip` and then use that
to install the `junit_xml` library for the Ansible output plugins we use
we should instead just do these installs in the base AMI once.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>