### PR TITLE
Retryable AMI lookups

### DIFF
--- a/oct/ansible/oct/playbooks/package/ami-mark-ready.yml
+++ b/oct/ansible/oct/playbooks/package/ami-mark-ready.yml
@@ -44,6 +44,9 @@
         sort_end: 1
         no_result_action: fail
       register: ami_facts
+      until: ami_facts.results is defined
+      retries: 5
+      delay: 10
 
     - name: determine which AMI to update
       set_fact:


### PR DESCRIPTION
The number one failure today of the build AMI is failed
AMI lookups.

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>