### PR TITLE
Stop installing Chrome and Chromedriver

### DIFF
--- a/oct/ansible/oct/roles/dependencies/tasks/install_dependencies.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/install_dependencies.yml
@@ -29,7 +29,6 @@
    - git                      # Interacting with repos
    - glibc-static             #
    - gnuplot                  # Origin test logger
-   - google-chrome-stable     # Origin Web Console tests
    - gpgme                    # Image Signature verification dep (containers/image)
    - gpgme-devel              #
    - hg                       #
@@ -85,15 +84,6 @@
         'CentOS',
         'RedHat'
       ]
-
-- name: install ChromeDriver to enable headless UI testing
-  unarchive:
-    src: https://chromedriver.storage.googleapis.com/2.16/chromedriver_linux64.zip
-    copy: no # TODO: change to `remote_src: yes` once https://github.com/ansible/ansible-modules-core/issues/4752 is fixed
-    dest: /usr/bin
-    mode: u=rwx,g=rx,o=rx
-    owner: root
-    creates: /usr/bin/chromedriver
 
 - name: update all packages to latest state
   package:

--- a/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
@@ -1,11 +1,4 @@
 ---
-- name: register Google Chrome repository
-  yum_repository:
-    name: google-chrome-stable
-    state: present
-    description: 'A repository containing a stable Goole Chrome release.'
-    baseurl: 'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
-
 - name: register RHEL 7 Atomic OpenShift repositories
   yum_repository:
     name: 'rhel-7-server-ose-{{ item }}-rpms'


### PR DESCRIPTION
The Origin Web Console team no longer runs headless testing on Chrome,
so we do not need to be installing these dependencies in the AMIs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @jwforres 