### PR TITLE
Add `bc` dependency to the base AMI

### DIFF
--- a/oct/ansible/oct/roles/dependencies/tasks/install_dependencies.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/install_dependencies.yml
@@ -9,6 +9,7 @@
   with_items:
    - ansible
    - augeas                   # developer UX
+   - bc                       # for Bash math
    - bind                     #
    - bind-utils               #
    - bridge-utils             #


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@richm can confirm our base AMI used to have this and does not anymore -- explicitly installing it now.