### PR TITLE
Allow for `fork` AMIs to have "QE" in their tags

### DIFF
--- a/oct/ansible/oct/roles/aws-up/tasks/main.yml
+++ b/oct/ansible/oct/roles/aws-up/tasks/main.yml
@@ -52,7 +52,7 @@
   set_fact:
     origin_ci_aws_ami_id: '{{ item.ami_id }}'
   with_items: '{{ ami_facts.results }}'
-  when: "'qe' not in item.tags"
+  when: "'qe' not in item.tags or origin_ci_aws_ami_stage == 'fork'"
 
 - name: determine which subnets are available
   ec2_vpc_subnet_facts:


### PR DESCRIPTION
When provisioning from a fork AMI, we need to allow for QE tags on the
image in EC2.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes #130 

This will allow for you to stand up the latest fork AMI, which is more useful than nothing but not the best. I am not super happy letting people pass in literal AMI IDs as if the AMI was not made with `oct` that's going to be a mess.

/cc @kargakis 