### PR TITLE
Fix oct deprovision with vagrant provider

### DIFF
--- a/oct/ansible/oct/roles/vagrant-up/files/vagrant.py
+++ b/oct/ansible/oct/roles/vagrant-up/files/vagrant.py
@@ -189,6 +189,9 @@ if options.list:
             'hosts': [],
             'vars': {},
         },
+        'vagrant': {
+            'hosts': [],
+        },
     }
 
     # load VM hosts


### PR DESCRIPTION
`oct deprovision` with vagrant provider is failing:

```console
(venv) [coder@host origin]$ oct deprovision
Traceback (most recent call last):
  File "/home/coder/git/src/github.com/openshift/origin/venv/bin/oct", line 11, in <module>
	load_entry_point('origin-ci-tool==0.1.0', 'console_scripts', 'oct')()
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/click/core.py", line 722, in call
	return self.main(*args, **kwargs)
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/click/core.py", line 697, in main
	rv = self.invoke(ctx)
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
	return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/click/core.py", line 895, in invoke
	return ctx.invoke(self.callback, **ctx.params)
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/click/core.py", line 535, in invoke
	return callback(*args, **kwargs)
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
	return f(get_current_context(), *args, **kwargs)
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/oct/cli/deprovision.py", line 36, in deprovision
	playbook_variables={'origin_ci_inventory_dir': context.obj.ansible_client_configuration.host_list, },
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/oct/config/configuration.py", line 139, in run_playbook
	option_overrides=option_overrides,
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/oct/config/ansible_client.py", line 140, in run_playbook
	host_list=self.host_list,
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/ansible/inventory/init.py", line 98, in init
	self.parse_inventory(host_list)
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/ansible/inventory/init.py", line 149, in parse_inventory
	self.parser = InventoryDirectory(loader=self._loader, groups=self.groups, filename=host_list)
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/ansible/inventory/dir.py", line 119, in init
	parser = get_file_parser(fullpath, self.groups, loader)
  File "/home/coder/git/src/github.com/openshift/origin/venv/lib/python2.7/site-packages/ansible/inventory/dir.py", line 84, in get_file_parser
	raise AnsibleError('\n'.join(myerr))
ansible.errors.AnsibleError: Attempted to execute "/home/coder/.config/origin-ci-tool/inventory/vagrant.py" as inventory script: Inventory script (/home/coder/.config/origin-ci-tool/inventory/vagrant.py) had an execution error: Traceback (most recent call last):
  File "/home/coder/.config/origin-ci-tool/inventory/vagrant.py", line 198, in <module>
	add_host_to_inventory(full_inventory, current_hostname, host_groups, host_variables)
  File "/home/coder/.config/origin-ci-tool/inventory/vagrant.py", line 137, in add_host_to_inventory
	inventory['vagrant']['hosts'].append(hostname)
KeyError: 'vagrant'
```

`add_host_to_inventory` is expecting that the `inventory` has key `vagrant`, so I updated the callers to prepare such structure.

PTAL @stevekuznetsov 
CC @simo5 