### PR TITLE
add online-hibernation to oct supported repos

### DIFF
--- a/oct/ansible/oct/roles/repositories/tasks/main.yml
+++ b/oct/ansible/oct/roles/repositories/tasks/main.yml
@@ -38,6 +38,7 @@
     - 'jenkins-openshift-login-plugin'
     - 'image-registry'
     - 'cluster-operator'
+    - 'online-hibernation'
 
 - name: initialize git directories for each private repository
   include: initialize_repository_placeholder.yml

--- a/oct/cli/util/repository_options.py
+++ b/oct/cli/util/repository_options.py
@@ -17,6 +17,7 @@ class Repository(object):
     metrics = 'origin-metrics'
     logging = 'origin-aggregated-logging'
     online = 'online'
+    online_hibernation = 'online-hibernation'
     release = 'release'
     aoscdjobs = 'aos-cd-jobs'
     openshift_ansible = 'openshift-ansible'
@@ -47,6 +48,7 @@ def repository_argument(func):
             Repository.metrics,
             Repository.logging,
             Repository.online,
+            Repository.online_hibernation,
             Repository.release,
             Repository.aoscdjobs,
             Repository.openshift_ansible,


### PR DESCRIPTION
@stevekuznetsov is this what is required to add openshift/online-hibernation to origin-ci-tool? 
Or, should I say, 'add oct to online-hibernation'? :)
Thanks