### PR TITLE
Add -D flag to docker daemon during builds

### DIFF
--- a/oct/ansible/oct/roles/docker/tasks/main.yml
+++ b/oct/ansible/oct/roles/docker/tasks/main.yml
@@ -14,6 +14,14 @@
     regexp: "^INSECURE_REGISTRY=.*"
     line: "INSECURE_REGISTRY='--insecure-registry={{ origin_ci_insecure_registries | join(' --insecure-registry=') }}'"
 
+- name: enable debug logging in the docker daemon
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    backrefs: yes
+    regexp: "^OPTIONS='(.*)'"
+    line: "OPTIONS='-D \\1'"
+
+
 - name: ensure no extra registries are added by the configuration
   lineinfile:
     backrefs: yes


### PR DESCRIPTION
Turn on debug logging to assist with docker issues during builds.


Signed-off-by: Jhon Honce <jhonce@redhat.com>