### PR TITLE
Remove command from the ami_id assignment

### DIFF
--- a/oct/cli/provision/remote/all_in_one.py
+++ b/oct/cli/provision/remote/all_in_one.py
@@ -205,7 +205,7 @@ def provision_with_aws(configuration, operating_system, stage, name, ami_id, dis
     }
 
     if ami_id is not None:
-        playbook_variables['origin_ci_aws_ami_id'] = ami_id,
+        playbook_variables['origin_ci_aws_ami_id'] = ami_id
 
     configuration.run_playbook(
         playbook_relative_path='provision/aws-up',


### PR DESCRIPTION
Otherwise the `oci provision ... --ami-id ID` complaints with

```vi
TASK [aws-up : provision an AWS EC2 instance] ******************************************************************************************************************************************************
task path: /home/jchaloup/Projects/src/github.com/openshift/origin-ci-tool/oct/ansible/oct/roles/aws-up/tasks/main.yml:90
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "generated_timestamp": "2017-12-13 17:18:47.230543", 
    "msg": "Instance creation failed => InvalidAMIID.Malformed: Invalid id: \"['ami-9781e3ed']\" (expecting \"ami-...\")"
}
```