### PR TITLE
Revert "Add -D flag to docker daemon during builds"

### DIFF
--- a/oct/ansible/oct/roles/docker/tasks/main.yml
+++ b/oct/ansible/oct/roles/docker/tasks/main.yml
@@ -14,14 +14,6 @@
     regexp: "^INSECURE_REGISTRY=.*"
     line: "INSECURE_REGISTRY='--insecure-registry={{ origin_ci_insecure_registries | join(' --insecure-registry=') }}'"
 
-- name: enable debug logging in the docker daemon
-  lineinfile:
-    dest: /etc/sysconfig/docker
-    backrefs: yes
-    regexp: "^OPTIONS='(.*)'"
-    line: "OPTIONS='-D \\1'"
-
-
 - name: ensure no extra registries are added by the configuration
   lineinfile:
     backrefs: yes


### PR DESCRIPTION
This reverts commit ad8c2849fcc340058d00a3bd930fde97eaa137d7.

The additional logging is causing rate limiting and container logs to be lost, leading to node e2e test failures.

@jwhonce @stevekuznetsov @ingvagabund @derekwaynecarr 
