### PR TITLE
remove devicemapper docker storage options

### DIFF
--- a/oct/ansible/oct/roles/docker/tasks/configure_docker_daemon_storage.yml
+++ b/oct/ansible/oct/roles/docker/tasks/configure_docker_daemon_storage.yml
@@ -12,10 +12,5 @@
     dest: /etc/sysconfig/docker-storage-setup
     line: "VG={{ origin_ci_docker_volume_group }}"
 
-- name: Set EXTRA_STORAGE_OPTIONS for docker-storage-setup
-  lineinfile:
-    dest: /etc/sysconfig/docker-storage-setup
-    line: "EXTRA_STORAGE_OPTIONS='--storage-opt dm.libdm_log_level=3'"
-
 - name: Run docker-storage-setup
   command: docker-storage-setup

--- a/oct/ansible/oct/roles/docker/tasks/configure_openshift_storage.yml
+++ b/oct/ansible/oct/roles/docker/tasks/configure_openshift_storage.yml
@@ -4,6 +4,7 @@
     vg: '{{ origin_ci_docker_volume_group }}'
     lv: 'openshift-xfs-vol-dir'
     size: '30%FREE'
+    shrink: no
     state: present
 
 - name: make the OpenShift XFS filesystem

--- a/oct/ansible/openshift-ansible/playbooks/libvirt/openshift-cluster/templates/user-data
+++ b/oct/ansible/openshift-ansible/playbooks/libvirt/openshift-cluster/templates/user-data
@@ -32,7 +32,6 @@ write_files:
     content: |
       DEVS=/dev/sdb
       VG=docker_vg
-      EXTRA_DOCKER_STORAGE_OPTIONS='--storage-opt dm.blkdiscard=true'
   - path: /etc/systemd/system/fstrim.timer.d/hourly.conf
     content: |
       [Timer]


### PR DESCRIPTION
We apparently use overlay2 only, and these options are causing dockerd
to fail to start. This should unblock AMI builds, among other things.