### PR TITLE
Enable AMI packaging ops on source AMIs

### DIFF
--- a/oct/ansible/oct/playbooks/package/ami-mark-ready.yml
+++ b/oct/ansible/oct/playbooks/package/ami-mark-ready.yml
@@ -30,27 +30,42 @@
       set_fact:
         origin_ci_aws_hostname: '{{ groups[origin_ci_hosts][0] }}'
 
-    - name: determine AWS EC2 AMI name
-      set_fact:
-        origin_ci_aws_ami_name: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_instance_name'] }}"
+    - name: Set AMI ID for AMI snapshotted from current instance
+      block:
+      - name: determine AWS EC2 AMI name
+        set_fact:
+          origin_ci_aws_ami_name: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_instance_name'] }}"
 
-    - name: search for an AMI to update
-      ec2_ami_find:
-        region: '{{ origin_ci_aws_region }}'
-        ami_tags:
-          Name: '{{ origin_ci_aws_ami_name }}'
-        sort: 'creationDate'
-        sort_order: descending
-        sort_end: 1
-        no_result_action: fail
-      register: ami_facts
-      until: ami_facts.results is defined
-      retries: 5
-      delay: 10
+      - name: search for an AMI to update
+        ec2_ami_find:
+          region: '{{ origin_ci_aws_region }}'
+          ami_tags:
+            Name: '{{ origin_ci_aws_ami_name }}'
+          sort: 'creationDate'
+          sort_order: descending
+          sort_end: 1
+          no_result_action: fail
+        register: ami_facts
+        retries: 5
+        delay: 10
 
-    - name: determine which AMI to update
-      set_fact:
-        origin_ci_aws_ami_id: '{{ ami_facts.results[0].ami_id }}'
+      - name: determine which AMI to update
+        set_fact:
+          origin_ci_aws_ami_id: '{{ ami_facts.results[0].ami_id }}'
+      when: origin_ci_aws_source_ami is not defined or not origin_ci_aws_source_ami
+
+    - name: Verify AMI ID for source AMI of current instance
+      block:
+        - name: determine AWS EC2 source AMI ID
+          set_fact:
+            origin_ci_aws_ami_id: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_ami_id'] }}"
+        - name: ensure AMI ID variable is set
+          fail:
+            msg: '{{ item }} must be set when updating source AMI.'
+          when: item not in vars and item not in hostvars[inventory_hostname]
+          with_items:
+            - origin_ci_aws_ami_id
+      when: origin_ci_aws_source_ami is defined and origin_ci_aws_source_ami
 
     - name: mark the AMI ready
       ec2_tag:
@@ -59,6 +74,7 @@
         tags: "{ '{{ item.key }}': '{{ item.value }}' }"
         state: present
       with_dict: "{{ origin_ci_aws_additional_tags }}"
+      when: "'ready' in origin_ci_aws_additional_tags and origin_ci_aws_additional_tags.ready|lower == 'yes'"
 
     - name: grant launch permissions
       ec2_ami:

--- a/oct/ansible/oct/playbooks/package/ami.yml
+++ b/oct/ansible/oct/playbooks/package/ami.yml
@@ -34,8 +34,8 @@
 
     - name: determine AWS EC2 image metadata
       set_fact:
-        origin_ci_aws_ami_os: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_ami_os'] }}"
-        origin_ci_aws_ami_stage: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_ami_stage'] }}"
+        origin_ci_aws_ami_os: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_ami_tags']['operating_system'] }}"
+        origin_ci_aws_ami_stage: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_ami_tags']['image_stage'] }}"
         origin_ci_aws_instance_id: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_instance_id'] }}"
         origin_ci_aws_instance_name: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_instance_name'] }}"
 
@@ -84,29 +84,42 @@
         content: '{{ origin_ci_aws_updated_host_vars.stdout }}'
         dest: '{{ origin_ci_aws_host_vars }}'
 
-    - name: determine AWS EC2 AMI name
-      set_fact:
-        origin_ci_aws_ami_name: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_instance_name'] }}"
-      when: "origin_ci_aws_additional_tags | length > 0"
+    - name: Set AMI ID for AMI snapshotted from current instance
+      block:
+      - name: determine AWS EC2 AMI name
+        set_fact:
+          origin_ci_aws_ami_name: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_instance_name'] }}"
 
-    - name: search for an AMI to update
-      ec2_ami_find:
-        region: '{{ origin_ci_aws_region }}'
-        ami_tags:
-          Name: '{{ origin_ci_aws_ami_name }}'
-        sort: 'creationDate'
-        sort_order: descending
-        sort_end: 1
-        no_result_action: fail
-      register: ami_facts
-      when: "origin_ci_aws_additional_tags | length > 0"
-      retries: 100
-      delay: 30
+      - name: search for an AMI to update
+        ec2_ami_find:
+          region: '{{ origin_ci_aws_region }}'
+          ami_tags:
+            Name: '{{ origin_ci_aws_ami_name }}'
+          sort: 'creationDate'
+          sort_order: descending
+          sort_end: 1
+          no_result_action: fail
+        register: ami_facts
+        retries: 5
+        delay: 10
 
-    - name: determine which AMI to update
-      set_fact:
-        origin_ci_aws_ami_id: '{{ ami_facts.results[0].ami_id }}'
-      when: "origin_ci_aws_additional_tags | length > 0"
+      - name: determine which AMI to update
+        set_fact:
+          origin_ci_aws_ami_id: '{{ ami_facts.results[0].ami_id }}'
+      when: origin_ci_aws_source_ami is not defined or not origin_ci_aws_source_ami
+
+    - name: Verify AMI ID for source AMI of current instance
+      block:
+        - name: determine AWS EC2 source AMI ID
+          set_fact:
+            origin_ci_aws_ami_id: "{{ hostvars[origin_ci_aws_hostname]['origin_ci_aws_ami_id'] }}"
+        - name: ensure AMI ID variable is set
+          fail:
+            msg: '{{ item }} must be set when updating source AMI.'
+          when: item not in vars and item not in hostvars[inventory_hostname]
+          with_items:
+            - origin_ci_aws_ami_id
+      when: origin_ci_aws_source_ami is defined and origin_ci_aws_source_ami
 
     - name: add any additional tags
       ec2_tag:

--- a/oct/ansible/oct/playbooks/provision/aws-up.yml
+++ b/oct/ansible/oct/playbooks/provision/aws-up.yml
@@ -15,8 +15,7 @@
         - origin_ci_aws_keypair_name
         - origin_ci_aws_private_key_path
         - origin_ci_aws_region
-        - origin_ci_aws_ami_os
-        - origin_ci_aws_ami_stage
+        - origin_ci_aws_ami_tags
         - origin_ci_aws_instance_name
         - origin_ci_aws_master_instance_type
         - origin_ci_aws_identifying_tag_key

--- a/oct/ansible/oct/roles/aws-up/tasks/main.yml
+++ b/oct/ansible/oct/roles/aws-up/tasks/main.yml
@@ -40,10 +40,7 @@
   - name: list available AMIs
     ec2_ami_find:
       region: '{{ origin_ci_aws_region }}'
-      ami_tags:
-        operating_system: '{{ origin_ci_aws_ami_os }}'
-        image_stage: '{{ origin_ci_aws_ami_stage }}'
-        ready: 'yes'
+      ami_tags: '{{ origin_ci_aws_ami_tags }}'
       sort: 'creationDate'
       sort_order: ascending
       no_result_action: fail
@@ -117,12 +114,12 @@
 - name: determine the default user to use for SSH
   set_fact:
     origin_ci_aws_ssh_user: 'ec2-user'
-  when: origin_ci_aws_ami_stage == 'bare'
+  when: origin_ci_aws_ami_tags.image_stage == 'bare'
 
 - name: determine the default user to use for SSH
   set_fact:
     origin_ci_aws_ssh_user: 'origin'
-  when: origin_ci_aws_ami_stage != 'bare'
+  when: origin_ci_aws_ami_tags.image_stage != 'bare'
 
 - name: update variables for the host
   copy:
@@ -131,8 +128,8 @@
       origin_ci_aws_hostname: '{{ origin_ci_aws_hostname }}'
       origin_ci_aws_instance_name: '{{ origin_ci_aws_instance_name }}'
       origin_ci_aws_instance_id: '{{ ec2.instance_ids[0] }}'
-      origin_ci_aws_ami_os: '{{ origin_ci_aws_ami_os }}'
-      origin_ci_aws_ami_stage: '{{ origin_ci_aws_ami_stage }}'
+      origin_ci_aws_ami_id: '{{ origin_ci_aws_ami_id }}'
+      origin_ci_aws_ami_tags: '{{ origin_ci_aws_ami_tags }}'
       ansible_ssh_private_key_file: '{{ origin_ci_aws_private_key_path }}'
       ansible_ssh_user: '{{ origin_ci_aws_ssh_user }}'
       ansible_ssh_extra_args: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o IdentitiesOnly=yes -o ConnectTimeout=0 -o ServerAliveInterval=30'


### PR DESCRIPTION
This adds `--source-ami` to `oct package ami` so that you can launch an
instance from a non-ready AMI, run acceptance tests, and then mark the
source AMI as ready if the tests pass.