### PR TITLE
Change image_ready to image_unready

### DIFF
--- a/oct/cli/image_not_ready.py
+++ b/oct/cli/image_not_ready.py
@@ -27,10 +27,10 @@ tagged ready, indicating that it has passed acceptance testing.
 \b
 Examples:
   See if the latest RHEL "base" image (A.K.A. AMI) in AWS has passed acceptance tests
-  $ oct image_ready --provider aws --os rhel --stage base
+  $ oct image_not_ready --provider aws --os rhel --stage base
 
   Check if the latest centos "build" image is *not* ready in AWS, suppress non-error output (e.g. for use in a script):
-  $ oct image_ready --provider aws --os centos --stage build --quiet
+  $ oct image_not_ready --provider aws --os centos --stage build --quiet
 ''',
 )
 @operating_system_option
@@ -39,19 +39,20 @@ Examples:
 @ami_id_option
 @pass_context
 @option('--quiet', '--silent', '-q', 'quiet', is_flag=True, help='Suppress standard output')
-def image_ready(context, operating_system, stage, provider, ami_id, quiet):
+def image_not_ready(context, operating_system, stage, provider, ami_id, quiet):
     """
-    Exit non-zero (raise exception) if most recent matching image is
-    not marked "ready"
+    Exit zero if most recent matching image is not marked "ready"
 
-    Otherwise, exit 0 if no matching images are found, or one or more
-    matching images are found and the *newest* one is tagged *ready*
+    Otherwise, exit non-zero if no matching images are found, or one
+    or more matching images are found and the *newest* one is tagged
+    *ready*
 
     :param operating_system: operating system tag to match on image
     :param stage:  image build stage to match on image
     :param provider: cloud provider (e.g. aws)
     :param ami_id: unique ID specifying AWS AMI; can't be used with
                    operating_system and stage options
+
     """
     if ami_id:
         if provider != Provider.aws:
@@ -59,12 +60,12 @@ def image_ready(context, operating_system, stage, provider, ami_id, quiet):
         if operating_system or stage:
             raise UsageError("AMI ID can't be used with search criteria like --operating-system or --stage")
     if provider == Provider.aws:
-        _aws_image_ready(operating_system, stage, ami_id, quiet)
+        _aws_image_not_ready(operating_system, stage, ami_id, quiet, context.obj.aws_variables.region)
 
 
-def _aws_image_ready(operating_system, stage, ami_id, quiet):
+def _aws_image_not_ready(operating_system, stage, ami_id, quiet, region):
     """
-    Implement image_ready logic for AWS AMIs
+    Implement image_not_ready logic for AWS AMIs
 
     :param operating_system: operating system tag to match on AMI
     :param stage:  image build stage to match on AMI
@@ -76,7 +77,7 @@ def _aws_image_ready(operating_system, stage, ami_id, quiet):
         filter.append({'Name': 'tag:operating_system', 'Values': [operating_system]})
     if stage:
         filter.append({'Name': 'tag:image_stage', 'Values': [stage]})
-    client = boto3.client('ec2')
+    client = boto3.client('ec2', region)
     res = None
     if ami_id:
         res = client.describe_images(ImageIds=[ami_id])
@@ -85,11 +86,11 @@ def _aws_image_ready(operating_system, stage, ami_id, quiet):
     # Sort the matching images from newest to oldest:
     images = sorted(res['Images'], key=lambda (x): datetime.strptime(x['CreationDate'], '%Y-%m-%dT%H:%M:%S.%fZ'), reverse=True)
     if not res['Images']:
-        quiet_echo(quiet, "No image was found matching the provided tags")
+        raise ClickException("No image was found matching the provided tags")
     else:
         newest = images[0]
         # If image is validated, "ready" tag will be "yes"
         if value_for_tag(newest['Tags'], 'ready').lower() == 'yes':
-            quiet_echo(quiet, "{} created {} is validated".format(image_info(newest), newest['CreationDate']))
+            raise ClickException("{} created {} is validated".format(image_info(newest), newest['CreationDate']))
         else:
-            raise ClickException("{} created {} is not yet validated".format(image_info(newest), newest['CreationDate']))
+            quiet_echo(quiet, "{} created {} is not yet validated".format(image_info(newest), newest['CreationDate']))

--- a/oct/oct.py
+++ b/oct/oct.py
@@ -8,7 +8,7 @@ from .cli.build.build import build
 from .cli.config.group import configure
 from .cli.deprovision import deprovision
 from .cli.download.group import download
-from .cli.image_ready import image_ready
+from .cli.image_not_ready import image_not_ready
 from .cli.install.install import install
 from .cli.make.make import make
 from .cli.package.group import package
@@ -41,7 +41,7 @@ oct_command.add_command(build)
 oct_command.add_command(configure)
 oct_command.add_command(deprovision)
 oct_command.add_command(download)
-oct_command.add_command(image_ready)
+oct_command.add_command(image_not_ready)
 oct_command.add_command(install)
 oct_command.add_command(make)
 oct_command.add_command(prepare)


### PR DESCRIPTION
This command is to test if there is an image *and* it's not tagged
"ready". Negating the result from `image_ready` meant that the ami test
job would run even if the command failed with an exception.

This also pulls the AWS region from the oct configuration since boto3
needs that if it's not persisted in the boto3 config on disk.