### PR TITLE
Add ansible-service-broker support

### DIFF
--- a/oct/ansible/oct/roles/repositories/tasks/main.yml
+++ b/oct/ansible/oct/roles/repositories/tasks/main.yml
@@ -44,6 +44,7 @@
     - 'online-console-extensions'
     - 'image-inspector'
     - 'service-catalog'
+    - 'ansible-service-broker'
 
 - name: initialize git directories for each private repository
   include: initialize_repository_placeholder.yml

--- a/oct/cli/util/repository_options.py
+++ b/oct/cli/util/repository_options.py
@@ -34,6 +34,7 @@ class Repository(object):
     image_inspector = 'image-inspector'
     online_registration = 'online-registration'
     service_catalog = 'service-catalog'
+    ansible_service_broker = 'ansible-service-broker'
 
 
 def repository_argument(func):
@@ -70,5 +71,6 @@ def repository_argument(func):
             Repository.image_inspector,
             Repository.online_registration,
             Repository.service_catalog,
+            Repository.ansible_service_broker,
         ])
     )(func)


### PR DESCRIPTION
Not quite sure how to test this, but `ansible-service-broker` support is needed in `oct` for https://github.com/openshift/aos-cd-jobs/pull/974. @stevekuznetsov @jpeeler does this make sense to you guys? Do the jenkins jobs pull from master here for their runs, or is some kind of a release required before the new oct tool is picked up?