### PR TITLE
Use strings for repo iteration

### DIFF
--- a/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
@@ -20,13 +20,13 @@
     sslclientcert: /var/lib/yum/client-cert.pem
     sslclientkey: /var/lib/yum/client-key.pem
   with_items:
-    - 3.6
-    - 3.7
-    - 3.8
-    - 3.9
-    - 3.10
-    - 3.11
-    - 3.12
+    - '3.6'
+    - '3.7'
+    - '3.8'
+    - '3.9'
+    - '3.10'
+    - '3.11'
+    - '3.12'
   when: ansible_distribution == 'RedHat'
 
 - name: turn on EPEL for the main dependency install


### PR DESCRIPTION
Fixes the following because it's interpreting the values as floats

```
TASK [dependencies : Register RHEL 7 Atomic OpenShift repositories] ************
changed: [172.18.9.149] => (item=3.6) => {
changed: [172.18.9.149] => (item=3.7) => {
changed: [172.18.9.149] => (item=3.8) => {
changed: [172.18.9.149] => (item=3.9) => {
changed: [172.18.9.149] => (item=3.1) => {
changed: [172.18.9.149] => (item=3.11) => {
changed: [172.18.9.149] => (item=3.12) => {
```