### PR TITLE
revert back to ansible_distribution

### DIFF
--- a/oct/ansible/oct/playbooks/bootstrap/ansible.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/ansible.yml
@@ -3,7 +3,7 @@
 # able to interact with this target host. Fedora
 # provides a nice grouping of RPMs for this purpose.
 - name: install bootstrap dependencies for Ansible target host
-  when: ansible_os_family != 'RedHat' or  ansible_distribution_major_version|int < 8
+  when: ansible_distribution != 'RedHat' or  ansible_distribution_major_version|int < 8
   raw: >
     if which dnf >/dev/null 2>&1; then
         dnf group install -y ansible-node && dnf install -y libselinux-python
@@ -14,7 +14,7 @@
 # RHEL 8 has a different installation work flow according to:
 # https://www.ansible.com/blog/integrating-ansible-and-red-hat-enterprise-linux-8-beta
 - name: install bootstrap dependencies for Ansible target host on RHEL 8
-  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version|int >= 8
+  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8
   raw: >
       yum -y module install python36
       pip3 install --install-option="--prefix=/usr" ansible


### PR DESCRIPTION
as ansible_os_family doesn't seem to be defined as I originally thought

Signed-off-by: Peter Hunt <pehunt@redhat.com>