### PR TITLE
Remove deprecated `pep8` & `--process-dependency-links` pip argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 # Install the origin-ci-tool on the local system.
 # NOTE: this target may require `sudo` privileges.
 install:
-	pip install . --process-dependency-links
+	pip install .
 .PHONY: install
 
 # Install the origin-ci-tool in the editable mode
 # using the extra development dependencies.
 install-development:
-	pip install --editable .[development] --process-dependency-links
+	pip install --editable .[development]
 .PHONY: install-development
 
 # Run the source code verification scripts.

--- a/hack/verify/pep8.sh
+++ b/hack/verify/pep8.sh
@@ -10,7 +10,7 @@ pushd "${oct_root}" >/dev/null 2>&1
 
 for source_file in $( find oct/ -not -path 'oct/ansible/openshift-ansible/*' -not -path 'oct/ansible/oct/roles/aws-up/files/ec2.py' -name '*.py' ); do
     echo "Checking ${source_file} for PEP8 compliance..."
-    if ! pep8 --show-source --show-pep8 --max-line-length 130 "${source_file}"; then
+    if ! pycodestyle --show-source --show-pep8 --max-line-length 130 "${source_file}"; then
         failed="true"
     fi
 done

--- a/oct/ansible/oct/callback_plugins/pretty_progress.py
+++ b/oct/ansible/oct/callback_plugins/pretty_progress.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 try:
-    from Queue import Empty ## for python 2
+    from Queue import Empty  # for python 2
 except ImportError:
-    from queue import Empty ## for python 3
+    from queue import Empty  # for python 3
 from multiprocessing import Process, Queue
 from os import environ
 from os.path import join

--- a/oct/ansible/openshift-ansible/utils/Makefile
+++ b/oct/ansible/openshift-ansible/utils/Makefile
@@ -102,11 +102,11 @@ ci-pep8:
 	@echo "#############################################"
 	@echo "# Running PEP8 Compliance Tests in virtualenv"
 	@echo "#############################################"
-	. $(NAME)env/bin/activate && pep8 --ignore=$(PEPEXCLUDES) src/$(SHORTNAME)/
-	. $(NAME)env/bin/activate && pep8 --ignore=$(PEPEXCLUDES) ../callback_plugins/openshift_quick_installer.py
+	. $(NAME)env/bin/activate && pycodestyle --ignore=$(PEPEXCLUDES) src/$(SHORTNAME)/
+	. $(NAME)env/bin/activate && pycodestyle --ignore=$(PEPEXCLUDES) ../callback_plugins/openshift_quick_installer.py
 # This one excludes E402 because it is an ansible module and the
 # boilerplate import statement is expected to be at the bottom
-	. $(NAME)env/bin/activate && pep8 --ignore=$(PEPEXCLUDES),E402 ../roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
+	. $(NAME)env/bin/activate && pycodestyle --ignore=$(PEPEXCLUDES),E402 ../roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
 
 ci: clean virtualenv ci-list-deps ci-pep8 ci-pylint ci-pyflakes ci-unittests
 	:

--- a/oct/ansible/openshift-ansible/utils/test-requirements.txt
+++ b/oct/ansible/openshift-ansible/utils/test-requirements.txt
@@ -1,7 +1,7 @@
 enum
 configparser
 pylint
-pep8
+pycodestyle
 nose
 coverage
 mock

--- a/oct/config/vagrant.py
+++ b/oct/config/vagrant.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import, division, print_function
 
 try:
-    from StringIO import StringIO ## for Python 2
+    from StringIO import StringIO  # for Python 2
 except ImportError:
-    from io import StringIO ## for Python 3
+    from io import StringIO  # for Python 3
 from copy import deepcopy
 from shutil import rmtree
 from subprocess import check_output

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 base_requires = [
     'Click',
-    'ansible==3.0.0',
+    'ansible @ git+https://github.com/stevekuznetsov/ansible.git@skuznets/oct-release#egg=ansible-3.0.0',
     'backports.shutil_get_terminal_size',
     'semver',
     'junit_xml',
@@ -14,7 +14,7 @@ base_requires = [
 test_requires = base_requires + [
     'mock',
     'coverage',
-    'pep8',
+    'pycodestyle',
     'yapf==0.14.0'
 ]
 
@@ -27,7 +27,6 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     dependency_links=[
-        'git+https://github.com/stevekuznetsov/ansible.git@skuznets/oct-release#egg=ansible-3.0.0'
     ],
     install_requires=base_requires,
     tests_require=test_requires,


### PR DESCRIPTION
`pip` > 19.0.0 no longer suppports the `--process-dependency-links`
argument. To coerce `pip` into installing the required customized
`ansible` package, the git URL has been added directly to the list
passed to `install_requires`

Additionally, the `pep8` code checking package has been renamed to
`pycodestyle`. References have been updated to cut down on noise
during the deprecation period.
