### PR TITLE
Force pip<19.0, Click<7.0 to fix travis tests, pep8<=1.7.0 for noise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 2.7
 install:
+  - pip install 'pip<19.0'
   - make install-development
 script:
   - make verify

--- a/oct/ansible/oct/callback_plugins/pretty_progress.py
+++ b/oct/ansible/oct/callback_plugins/pretty_progress.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 try:
-    from Queue import Empty ## for python 2
+    from Queue import Empty  # for python 2
 except ImportError:
-    from queue import Empty ## for python 3
+    from queue import Empty  # for python 3
 from multiprocessing import Process, Queue
 from os import environ
 from os.path import join

--- a/oct/config/vagrant.py
+++ b/oct/config/vagrant.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import, division, print_function
 
 try:
-    from StringIO import StringIO ## for Python 2
+    from StringIO import StringIO  # for Python 2
 except ImportError:
-    from io import StringIO ## for Python 3
+    from io import StringIO  # for Python 3
 from copy import deepcopy
 from shutil import rmtree
 from subprocess import check_output

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 base_requires = [
-    'Click',
+    'Click<7.0',
     'ansible==3.0.0',
     'backports.shutil_get_terminal_size',
     'semver',
@@ -14,7 +14,7 @@ base_requires = [
 test_requires = base_requires + [
     'mock',
     'coverage',
-    'pep8',
+    'pep8<=1.7.0',
     'yapf==0.14.0'
 ]
 


### PR DESCRIPTION
`pip` >= `19.0` drops the `--process-dependency-links` argument
support. Forcing `pip` versions older than `19.0` lets us install the
required `ansible` custom fork without complicating `setup.py` to
accommodate the requirements of `pip` after version `19.0`.

`pep8` <= `1.7.0` won't nag about the rename to `pycodestyle`.

`Click` < `7.0` preserves the output formatting for bad/missing
arguments that the unit tests expect.

Comment format in a couple of files was fixed to match `pep8`
standards
