### PR TITLE
allow for f30 to use python3 rules

### DIFF
--- a/oct/ansible/oct/playbooks/bootstrap/ansible.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/ansible.yml
@@ -1,9 +1,13 @@
 ---
+- name:
+  include_vars:
+    file: python3.yml
+
 # Install dependencies necessary for Ansible to be
 # able to interact with this target host. Fedora
 # provides a nice grouping of RPMs for this purpose.
 - name: install bootstrap dependencies for Ansible target host
-  when: ansible_distribution != 'RedHat' or  ansible_distribution_major_version|int < 8
+  when: not supports_python3
   raw: >
     if which dnf >/dev/null 2>&1; then
         dnf group install -y ansible-node && dnf install -y libselinux-python ansible
@@ -15,8 +19,8 @@
 # https://www.ansible.com/blog/integrating-ansible-and-red-hat-enterprise-linux-8-beta
 # oct also expects the binary python to be on the host, so add a symlink
 - name: install bootstrap dependencies for Ansible target host on RHEL 8
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8
+  when: supports_python3
   raw: >
       yum install -y python3 python3-dnf gcc redhat-rpm-config python3-devel;
       alternatives --set python /usr/bin/python3;
-      pip3 install --install-option="--prefix=/usr" ansible;
+      pip install --install-option="--prefix=/usr" ansible;

--- a/oct/ansible/oct/playbooks/bootstrap/python3.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/python3.yml
@@ -1,0 +1,2 @@
+---
+supports_python3: (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8) or (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 30)

--- a/oct/ansible/oct/playbooks/bootstrap/self.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/self.yml
@@ -32,7 +32,12 @@
   gather_facts: yes
 
   tasks:
+    - name:
+      include_vars:
+        file: python3.yml
+
     - name: install requisite dependencies to enable functionality
+      when: not supports_python3
       package:
         name: '{{ item }}'
         state: present
@@ -41,14 +46,13 @@
         - pyOpenSSL
         - python-boto
         - python-boto3
-      when: ansible_distribution != 'RedHat' or  ansible_distribution_major_version|int < 8
 
     # haircommander: while hacky, I ran into lots of trouble trying to use the ansible package
     - name: install requisite dependencies to enable functionality for RHEL 8
-      when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8
+      when: supports_python3
       raw: >
         yum install -y python3-libselinux python3-pyOpenSSL;
-        pip3 install --install-option="--prefix=/usr" boto3 boto;
+        pip install --install-option="--prefix=/usr" boto3 boto;
 
 
     - name: install requisite dependencies to enable image building functionality


### PR DESCRIPTION
Make some changes so Fedora 30 can use the alternative paths (as it has also deprecated python2-dnf)

Signed-off-by: Peter Hunt <pehunt@redhat.com>