### PR TITLE
two fixes

### DIFF
--- a/oct/ansible/oct/callback_plugins/pretty_progress.py
+++ b/oct/ansible/oct/callback_plugins/pretty_progress.py
@@ -70,11 +70,17 @@ def display_workload(queue):
 
         # navigate to the top to over-write the last output
         for i in range(last_num_lines):
-            stdout.buffer.write(MOVE_UP_ONE_LINE)
+            try: # for python3
+               stdout.buffer.write(MOVE_UP_ONE_LINE)
+            except AttributeError: # for python2
+               stdout.write(MOVE_UP_ONE_LINE)
             if i < last_num_lines - len(workload):
                 # if there are lines in the old output which
                 # we may not overwrite, just clear them
-                stdout.buffer.write(CLEAR_LINE)
+                try: # for python3
+                    stdout.buffer.write(CLEAR_LINE)
+                except AttributeError: # for python2
+                    stdout.write(CLEAR_LINE)
 
         # re-render and print the new output
         last_num_lines = 0

--- a/oct/ansible/oct/playbooks/bootstrap/ansible.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/ansible.yml
@@ -7,7 +7,7 @@
 # able to interact with this target host. Fedora
 # provides a nice grouping of RPMs for this purpose.
 - name: install bootstrap dependencies for Ansible target host
-  when: not supports_python3
+  when: not supports_python3|bool
   raw: >
     if which dnf >/dev/null 2>&1; then
         dnf group install -y ansible-node && dnf install -y libselinux-python ansible
@@ -19,7 +19,7 @@
 # https://www.ansible.com/blog/integrating-ansible-and-red-hat-enterprise-linux-8-beta
 # oct also expects the binary python to be on the host, so add a symlink
 - name: install bootstrap dependencies for Ansible target host on RHEL 8
-  when: supports_python3
+  when: supports_python3|bool
   raw: >
       yum install -y python3 python3-dnf gcc redhat-rpm-config python3-devel;
       alternatives --set python /usr/bin/python3;

--- a/oct/ansible/oct/playbooks/bootstrap/self.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/self.yml
@@ -37,7 +37,7 @@
         file: python3.yml
 
     - name: install requisite dependencies to enable functionality
-      when: not supports_python3
+      when: not supports_python3|bool
       package:
         name: '{{ item }}'
         state: present
@@ -49,7 +49,7 @@
 
     # haircommander: while hacky, I ran into lots of trouble trying to use the ansible package
     - name: install requisite dependencies to enable functionality for RHEL 8
-      when: supports_python3
+      when: supports_python3|bool
       raw: >
         yum install -y python3-libselinux python3-pyOpenSSL;
         pip install --install-option="--prefix=/usr" boto3 boto;

--- a/oct/ansible/oct/playbooks/provision/lvm2.yml
+++ b/oct/ansible/oct/playbooks/provision/lvm2.yml
@@ -4,11 +4,11 @@
     file: python3.yml
 
 - name: download lvm2 for non-RHEL8 hosts
-  when: not supports_python3
+  when: not supports_python3|bool
   package:
     name: lvm2
     state: present
 
 - name: download lvm2 for RHEL8 hosts
-  when: supports_python3
+  when: supports_python3|bool
   command: yum install -y lvm2


### PR DESCRIPTION
- continue supporting python2 by catching an attribute error on a fix for python3
- use |bool when evaluating supports_python3, because in some cases it is not evaluated properly