### PR TITLE
AMI build fixes for key rotation and build speed

### DIFF
--- a/oct/ansible/oct/playbooks/prepare/user.yml
+++ b/oct/ansible/oct/playbooks/prepare/user.yml
@@ -35,6 +35,23 @@
         line: '{{ origin_ci_user }}  ALL=(ALL)  NOPASSWD: ALL'
         state: present
 
+    - name: ensure cloud-init is configured for the new user
+      lineinfile:
+        dest: /etc/cloud/cloud.cfg.d/00_ec2-user.cfg
+        regexp: '^    name:'
+        line: '    name: {{origin_ci_user}}'
+        state: present
+
+    - name: remove cloud-init instance data cache
+      file:
+        path: /var/lib/cloud/instances
+        state: absent
+
+    - name: remove cloud-init current instance symlink
+      file:
+        path: /var/lib/cloud/instance
+        state: absent
+
     - name: ensure the user has home directories
       file:
         path: '{{ item }}'

--- a/oct/ansible/oct/playbooks/provision/aws-docker-storage.yml
+++ b/oct/ansible/oct/playbooks/provision/aws-docker-storage.yml
@@ -30,7 +30,7 @@
       include: lvm2.yml
 
     - name: ensure the new space is empty
-      command: '/usr/bin/dd if=/dev/zero of=/dev/xvdb bs=1M'
+      command: '/sbin/wipefs -a /dev/xvdb'
       ignore_errors: true
 
     - name: ensure changes are synced to disk


### PR DESCRIPTION
`cloud-init` needs to be properly configured for the SSH user so that the keypair selected at instance launch is correctly added to the SSH user's `~/.ssh/authorized_keys` file.

This also replaces a `dd` invocation with `wipefs` to remove partitions from the second disk. This saves several minutes.