### PR TITLE
image_options: add new os fedora-cgroupv2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,7 +241,7 @@ support the VM, then run:
                                      --provider NAME \ #<2>
                                      --stage STAGE     #<3>
 
-1. Select the operating system you would like to use with ``--os``. Fedora and CentOS are supported.
+1. Select the operating system you would like to use with ``--os``. Fedora, Fedora-cgroupv2 and CentOS are supported.
 2. Choose the virtualization provider to use. LibVirt, VirtualBox and VMWare Fusion are supported.
 3. Determine the image stage to base the virtual machine on. Valid image stages are ``bare``, ``base`` and ``install``. Only the
    bare OS stage is supported for VMWare Fusion.

--- a/oct/ansible/oct/callback_plugins/pretty_progress.py
+++ b/oct/ansible/oct/callback_plugins/pretty_progress.py
@@ -70,16 +70,16 @@ def display_workload(queue):
 
         # navigate to the top to over-write the last output
         for i in range(last_num_lines):
-            try: # for python3
-               stdout.buffer.write(MOVE_UP_ONE_LINE)
-            except AttributeError: # for python2
-               stdout.write(MOVE_UP_ONE_LINE)
+            try:  # for python3
+                stdout.buffer.write(MOVE_UP_ONE_LINE)
+            except AttributeError:  # for python2
+                stdout.write(MOVE_UP_ONE_LINE)
             if i < last_num_lines - len(workload):
                 # if there are lines in the old output which
                 # we may not overwrite, just clear them
-                try: # for python3
+                try:  # for python3
                     stdout.buffer.write(CLEAR_LINE)
-                except AttributeError: # for python2
+                except AttributeError:  # for python2
                     stdout.write(CLEAR_LINE)
 
         # re-render and print the new output

--- a/oct/cli/util/cloud_provider/image_options.py
+++ b/oct/cli/util/cloud_provider/image_options.py
@@ -10,6 +10,7 @@ class OperatingSystem(object):
     Vagrant provisioning of VMs.
     """
     fedora = 'fedora'
+    fedora_cgroup2 = 'fedora-cgroupv2'
     centos = 'centos'
     rhel = 'rhel'
 
@@ -45,6 +46,7 @@ def operating_system_option(func):
         'operating_system',
         type=Choice([
             OperatingSystem.fedora,
+            OperatingSystem.fedora_cgroup2,
             OperatingSystem.centos,
             OperatingSystem.rhel,
         ]),


### PR DESCRIPTION
add a new operating system "fedora-cgroupv2" to target Fedora running
with the cgroup v2 unified hierarchy.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>