### PR TITLE
WiP - bootstrap: fix pip install with newer pip releases

### DIFF
--- a/oct/ansible/oct/playbooks/bootstrap/ansible.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/ansible.yml
@@ -22,4 +22,4 @@
   raw: >
       yum install -y python3 python3-dnf gcc redhat-rpm-config python3-devel;
       alternatives --set python /usr/bin/python3;
-      pip install --install-option="--prefix=/usr" ansible;
+      pip install ansible;

--- a/oct/ansible/oct/playbooks/bootstrap/self.yml
+++ b/oct/ansible/oct/playbooks/bootstrap/self.yml
@@ -51,7 +51,7 @@
       when: supports_python3 is defined and supports_python3
       raw: >
         yum install -y python3-libselinux python3-pyOpenSSL;
-        pip install --install-option="--prefix=/usr" boto3 boto;
+        pip install boto3 boto;
 
 
     - name: install requisite dependencies to enable image building functionality

--- a/oct/config/ansible_client.py
+++ b/oct/config/ansible_client.py
@@ -11,10 +11,10 @@ from ansible import constants
 from ansible.cli.playbook import PlaybookCLI
 from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.executor.task_queue_manager import TaskQueueManager
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.plugins import callback_loader
-from ansible.vars import VariableManager
+from ansible.plugins.loader import callback_loader
+from ansible.vars.manager import VariableManager
 from click import ClickException
 
 DEFAULT_VERBOSITY = 1
@@ -136,9 +136,9 @@ class AnsibleCoreClient(object):
         data_loader = DataLoader()
         inventory = Inventory(
             loader=data_loader,
-            variable_manager=variable_manager,
-            host_list=self.host_list,
+            sources=self.host_list,
         )
+        variable_manager = VariableManager(loader=data_loader, inventory=inventory)
         variable_manager.set_inventory(inventory)
         variable_manager.extra_vars = playbook_variables
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ base_requires = [
 test_requires = base_requires + [
     'mock',
     'coverage',
+    'paramiko',
     'pep8<=1.7.0',
     'yapf==0.14.0'
 ]


### PR DESCRIPTION
the '--install-option="--prefix=/install"' option of the pip install
command [is no more supported in the latest pip versions](https://github.com/pypa/pip/issues/9435) (as the one
available in Fedora 34):

ERROR: Location-changing options found in --install-option: ['--prefix'] from command line. This is unsupported, use pip-level options like --user, --prefix, --root, and --target instead.
Checking the --prefix, --root and --target options seems none of them
can allow the ansible binary to be installed under /usr/bin/ (it will
installed under /usr/local/bin/ in any case).
The only option seems to drop the '--install-option="--prefix=/usr" ' : seems to me it
shouldn't hurt, as the rpm ansible package shouldn't be installed when installed via the pip tool.