### PR TITLE
Change yum repo for mirror.openshift.com to use user/password authentication

### DIFF
--- a/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
@@ -47,8 +47,8 @@
       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,
       https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
     sslverify: no
-    username: <something>
-    password: <something>
+    username: "{{ lookup('env', ''MIRROR_OS_USER) }}"
+    password: "{{ lookup('env', ''MIRROR_OS_PASS) }}"
   when: ansible_distribution == 'RedHat'
   with_items:
     - '2.4'

--- a/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
@@ -47,8 +47,8 @@
       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,
       https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
     sslverify: no
-    sslclientcert: /var/lib/yum/client-cert.pem
-    sslclientkey: /var/lib/yum/client-key.pem
+    username: <something>
+    password: <something>
   when: ansible_distribution == 'RedHat'
   with_items:
     - '2.4'


### PR DESCRIPTION
mirror.openshift.com no longer uses certificate authentication.

There's now a file in on the jenkins server at `/var/lib/jenkins` that contains environment variables for the creds. In [this PR](https://github.com/openshift/aos-cd-jobs/pull/2880) we'll source that file so relevant variables are available to the ansible playbook that sets up the yum config.