### PR TITLE
Use user/pass auth for mirrors; cert no longer accepted

### DIFF
--- a/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
+++ b/oct/ansible/oct/roles/dependencies/tasks/register_repositories.yml
@@ -17,8 +17,8 @@
       https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
     failovermethod: priority
     sslverify: no
-    sslclientcert: /var/lib/yum/client-cert.pem
-    sslclientkey: /var/lib/yum/client-key.pem
+    username: "{{ lookup('env', ''MIRROR_OS_USER) }}"
+    password: "{{ lookup('env', ''MIRROR_OS_PASS) }}"
   with_items:
     - '3.6'
     - '3.7'


### PR DESCRIPTION
This will hopefully address the problem in this [log](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_jenkins/1373/pull-ci-openshift-jenkins-openshift-3.11-e2e-gcp-jenkins/1486475234184794112) where certificate authentication is rejected.